### PR TITLE
core-toolbar -> paper-toolbar

### DIFF
--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -20,9 +20,9 @@ the `paper-header-panel` fill the screen
 
     <body class="fullbleed layout vertical">
       <paper-header-panel class="flex">
-        <core-toolbar>
+        <paper-toolbar>
           <div>Hello World!</div>
-        </core-toolbar>
+        </paper-toolbar>
       </paper-header-panel>
     </body>
 
@@ -38,17 +38,17 @@ or, if you would prefer to do it in CSS, give `html`, `body`, and `paper-header-
       height: 100%;
     }
 
-Special support is provided for scrolling modes when one uses a core-toolbar or equivalent for the
+Special support is provided for scrolling modes when one uses a paper-toolbar or equivalent for the
 header section.
 
 Example:
 
     <paper-header-panel>
-      <core-toolbar>Header</core-toolbar>
+      <paper-toolbar>Header</paper-toolbar>
       <div>Content goes here...</div>
     </paper-header-panel>
 
-If you want to use other than `core-toolbar` for the header, add `paper-header` class to that
+If you want to use other than `paper-toolbar` for the header, add `paper-header` class to that
 element.
 
 Example:
@@ -145,7 +145,7 @@ Use `mode` to control the header and scrolling behavior.
   <template>
     <div id="outerContainer" class="layout vertical">
 
-      <content id="headerContent" select="core-toolbar, .paper-header"></content>
+      <content id="headerContent" select="paper-toolbar, .paper-header"></content>
 
       <div id="mainPanel" class="layout vertical flex">
 
@@ -244,9 +244,9 @@ Use `mode` to control the header and scrolling behavior.
          *     </style>
          *
          *     <paper-header-panel mode="cover">
-         *       <core-toolbar class="tall">
+         *       <paper-toolbar class="tall">
          *         <core-icon-button icon="menu"></core-icon-button>
-         *       </core-toolbar>
+         *       </paper-toolbar>
          *       <div class="content"></div>
          *     </paper-header-panel>
          *


### PR DESCRIPTION
**core-toolbar isn't compatible with Polymer 0.8 and will be
deprecated.**
Use a similar 0.8-compatible version of this element instead
[paper-toolbar](https://github.com/polymerelements/paper-toolbar)

Signed-off-by: Vandeuren Glenn vandeurenglenn@gmail.com
