### PR TITLE
Add overflow: hidden to #mainPanel

### DIFF
--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -90,6 +90,7 @@ Use `mode` to control the header and scrolling behavior.
 
     #mainPanel {
       position: relative;
+      overflow: hidden;
     }
 
     #mainContainer {


### PR DESCRIPTION
I don't know exactly what the cause, but I had a `paper-header-panel` that was misbehaving because `#mainPanel` somehow had full content height instead of fitting to the window size. Scrolling was broken and other problems cropped up. Adding `overflow: hidden` fixed this by causing `#mainContainer` to take full control over layout overflow and scrolling.
