### PR TITLE
Io polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,24 +17,7 @@ the `paper-header-panel` fill the screen
 </body>
 ```
 
-or, if you would prefer to do it in CSS, give `html`, `body`, and `paper-header-panel` a height of
-100%:
-
-```css
-html, body {
-  height: 100%;
-  margin: 0;
-}
-
-paper-header-panel {
-  height: 100%;
-}
-```
-
-Special support is provided for scrolling modes when one uses a paper-toolbar or equivalent for the
-header section.
-
-Example:
+Special support is provided for scrolling modes when one uses a `paper-toolbar` or equivalent for the header section. For example:
 
 ```html
 <paper-header-panel>
@@ -44,9 +27,7 @@ Example:
 ```
 
 If you want to use other than `paper-toolbar` for the header, add `paper-header` class to that
-element.
-
-Example:
+element:
 
 ```html
 <paper-header-panel>
@@ -55,7 +36,7 @@ Example:
 </paper-header-panel>
 ```
 
-To have the content fit to the main area, use the `fit` class.
+To have the content fit to the main area, use the `fit` class:
 
 ```html
 <paper-header-panel>
@@ -64,9 +45,30 @@ To have the content fit to the main area, use the `fit` class.
 </paper-header-panel>
 ```
 
-Use `mode` to control the header and scrolling behavior.
+### Mode
 
-Styling header panel:
+Controls header and scrolling behavior. Options are `standard`, `seamed`, `waterfall`, `waterfall-tall`, `scroll` and
+`cover`. Default is `standard`.
+
+Mode | Description
+----------------|-------------
+`standard` | The header is a step above the panel. The header will consume the panel at the point of entry, preventing it from passing through to the opposite side.
+`seamed` | The header is presented as seamed with the panel.
+`waterfall` | Similar to standard mode, but header is initially presented as seamed with panel, but then separates to form the step.
+`waterfall-tall` | The header is initially taller (`tall` class is added to the header). As the user scrolls, the header separates (forming an edge) while condensing (`tall` class is removed from the header).
+`scroll` | The header keeps its seam with the panel, and is pushed off screen.
+`cover` | The panel covers the whole `paper-header-panel` including the header. This allows user to style the panel in such a way that the panel is partially covering the header.
+
+Example: 
+
+```html
+<paper-header-panel mode="waterfall">
+  <div class="paper-header">standard</div>
+  <div class="content fit">content fits 100% below the header</div>
+</paper-header-panel>
+```
+
+### Styling header panel:
 
 To change the shadow that shows up underneath the header:
 
@@ -85,6 +87,18 @@ To change the panel container:
 ```css
 paper-slider {
   --paper-header-panel-standard-container: {
+    border: 1px solid gray;
+  };
+
+  --paper-header-panel-cover-container: {
+    border: 1px solid gray;
+  };
+
+  --paper-header-panel-waterfall-container: {
+    border: 1px solid gray;
+  };
+
+  --paper-header-panel-waterfall-tall-container: {
     border: 1px solid gray;
   };
 }

--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -15,8 +15,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 __Important:__ The `paper-header-panel` will not display if its parent does not have a height.
 
-Using [layout classes](http://www.polymer-project.org/docs/polymer/layout-attrs.html), you can make
-the `paper-header-panel` fill the screen
+Using layout classes, you can make the `paper-header-panel` fill the screen
 
     <body class="fullbleed layout vertical">
       <paper-header-panel class="flex">
@@ -25,18 +24,6 @@ the `paper-header-panel` fill the screen
         </paper-toolbar>
       </paper-header-panel>
     </body>
-
-or, if you would prefer to do it in CSS, give `html`, `body`, and `paper-header-panel` a height of
-100%:
-
-    html, body {
-      height: 100%;
-      margin: 0;
-    }
-
-    paper-header-panel {
-      height: 100%;
-    }
 
 Special support is provided for scrolling modes when one uses a paper-toolbar or equivalent for the
 header section.
@@ -62,10 +49,30 @@ To have the content fit to the main area, use the `fit` class.
 
     <paper-header-panel>
       <div class="paper-header">standard</div>
+      <div class="fit">content fits 100% below the header</div>
+    </paper-header-panel>
+
+Modes
+
+Controls header and scrolling behavior. Options are `standard`, `seamed`, `waterfall`, `waterfall-tall`, `scroll` and
+`cover`. Default is `standard`.
+
+Mode | Description
+----------------|-------------
+`standard` | The header is a step above the panel. The header will consume the panel at the point of entry, preventing it from passing through to the opposite side.
+`seamed` | The header is presented as seamed with the panel.
+`waterfall` | Similar to standard mode, but header is initially presented as seamed with panel, but then separates to form the step.
+`waterfall-tall` | The header is initially taller (`tall` class is added to the header). As the user scrolls, the header separates (forming an edge) while condensing (`tall` class is removed from the header).
+`scroll` | The header keeps its seam with the panel, and is pushed off screen.
+`cover` | The panel covers the whole `paper-header-panel` including the header. This allows user to style the panel in such a way that the panel is partially covering the header.
+
+Example: 
+
+    <paper-header-panel mode="waterfall">
+      <div class="paper-header">standard</div>
       <div class="content fit">content fits 100% below the header</div>
     </paper-header-panel>
 
-Use `mode` to control the header and scrolling behavior.
 
 Styling header panel:
 
@@ -79,10 +86,22 @@ To change the shadow that shows up underneath the header:
       };
     }
 
-To change the panel container:
+To change the panel container in different modes:
 
     paper-slider {
       --paper-header-panel-standard-container: {
+        border: 1px solid gray;
+      };
+
+      --paper-header-panel-cover-container: {
+        border: 1px solid gray;
+      };
+
+      --paper-header-panel-waterfall-container: {
+        border: 1px solid gray;
+      };
+
+      --paper-header-panel-waterfall-tall-container: {
         border: 1px solid gray;
       };
     }
@@ -292,15 +311,6 @@ To change the panel container:
          * `cover`: The panel covers the whole `paper-header-panel` including the
          * header. This allows user to style the panel in such a way that the panel is
          * partially covering the header.
-         *
-         *     <style>
-         *       paper-header-panel[mode=cover]::shadow #mainContainer {
-         *         left: 80px;
-         *       }
-         *       .content {
-         *         margin: 60px 60px 60px 0;
-         *       }
-         *     </style>
          *
          *     <paper-header-panel mode="cover">
          *       <paper-toolbar class="tall">

--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -129,6 +129,7 @@ To change the panel container in different modes:
 
       display: block;
       position: relative;
+      height: 100%;
 
       /* Create a stack context, we will need it for the shadow*/
       z-index: 0;


### PR DESCRIPTION
- Improve the docs.
- Set the default height to `100%` 

I was looking at the CSS of `app-layout-templates` and noticed that it was manually setting the height.  https://github.com/PolymerElements/app-layout-templates/blob/master/nav-list-detail/src/x-app.css#L14-L32  Additionally, the docs was confusing: https://github.com/PolymerElements/paper-drawer-panel/issues/27

cc @cdata @morethanreal @notwaldorf @frankiefu 
