### PR TITLE
Use Strings as Object Key Names to Prevent JS Closure Renaming

### DIFF
--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -142,12 +142,12 @@ To change the panel container in different modes:
     var MODE_CONFIGS = {
 
       outerScroll: {
-        scroll: true
+        'scroll': true
       },
 
       shadowMode: {
-        standard: SHADOW_ALWAYS,
-        waterfall: SHADOW_WHEN_SCROLLING,
+        'standard': SHADOW_ALWAYS,
+        'waterfall': SHADOW_WHEN_SCROLLING,
         'waterfall-tall': SHADOW_WHEN_SCROLLING
       },
 


### PR DESCRIPTION
Each object in MODE_CONFIGS contains string literal keys referenced by a
string property.
