### PR TITLE
fix height adjustment

### DIFF
--- a/paper-header-panel.css
+++ b/paper-header-panel.css
@@ -12,7 +12,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   @apply(--layout-vertical);
 
   position: relative;
-  height: 100%;
+  height: auto;
 }
 
 /**


### PR DESCRIPTION
This should fix issue #34, which occurs  if a sibling element and it's children contain css `background-cover` along with `fit`. 
