### PR TITLE
Fixed typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To change the shadow that shows up underneath the header:
     }
 To change the panel container in different modes:
 
-    paper-slider {
+    paper-header-panel {
       --paper-header-panel-standard-container: {
         border: 1px solid gray;
       };

--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -88,7 +88,7 @@ To change the shadow that shows up underneath the header:
 
 To change the panel container in different modes:
 
-    paper-slider {
+    paper-header-panel {
       --paper-header-panel-standard-container: {
         border: 1px solid gray;
       };


### PR DESCRIPTION
Documentation incorrectly references `paper-slider`  instead of `paper-header-panel`
