### PR TITLE
Remove reference to nonexistant file

### DIFF
--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -9,7 +9,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="paper-header-panel-styles.html">
 
 <!--
 `paper-header-panel` contains a header section and a content panel section.


### PR DESCRIPTION
Looks like the style was inlined but the HTML import was left behind.

This fix should land before we cut a release on this element, as the bad reference crashes hydrolysis (and thus vulcanize) for me.
