### PR TITLE
Do not display drop shadow in seamed mode.

### DIFF
--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -231,6 +231,10 @@ Custom property | Description | Default
         @apply(--paper-header-panel-waterfall-tall-container);
       }
 
+      :host([mode=seamed]) #dropShadow {
+        display: none;
+      }
+
       #dropShadow {
         @apply(--paper-header-panel-shadow);
 


### PR DESCRIPTION
Hi,

I have a case where the drop shadow overlaps an element with a graphical layer. It creates other graphical layers (layerForSquashingContents, Composition due to...) and therefore add time to composition. In seamed mode, I do not need this layer.

Thanks
