### PR TITLE
Allow styling the panel container in any mode

### DIFF
--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -87,6 +87,13 @@ To change the shadow that shows up underneath the header:
       };
     }
 
+To change the panel container:
+
+    paper-header-panel {
+      --paper-header-panel-container: {
+        border: 1px solid gray;
+      };
+
 To change the panel container in different modes:
 
     paper-header-panel {
@@ -121,6 +128,7 @@ Custom property | Description | Default
 ----------------|-------------|----------
 `--paper-header-panel` | Mixin applied to the element | `{}`
 `--paper-header-panel-body` | Mixin applied to the element's body (i.e. everything below the toolbar) | `{}`
+`--paper-header-panel-container` | Mixin applied to the container in any mode | `{}`
 `--paper-header-panel-scroll-container` | Mixin applied to the container when in scroll mode | `{}`
 `--paper-header-panel-cover-container` | Mixin applied to the container when in cover mode | `{}`
 `--paper-header-panel-standard-container` | Mixin applied to the container when in standard mode | `{}`
@@ -164,6 +172,10 @@ Custom property | Description | Default
         min-height: 0;
 
         @apply(--paper-header-panel-body);
+      }
+
+      #mainContainer {
+        @apply(--paper-header-panel-container);
       }
 
       /*


### PR DESCRIPTION
Provides a convenience mixin so users don't want to consider every possible mode when
adding general styles to the container.
