### PR TITLE
Add print media rules

### DIFF
--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -167,9 +167,15 @@ Custom property | Description | Default
       }
       
       @media print {
-        :host { display: block }
-        #mainContainer { display: block }
-        #mainPanel { display: block }
+        :host {
+          display: block;
+        }
+        #mainContainer {
+          display: block;
+        }
+        #mainPanel {
+          display: block;
+        }
       }
 
       /*

--- a/paper-header-panel.html
+++ b/paper-header-panel.html
@@ -165,6 +165,12 @@ Custom property | Description | Default
 
         @apply(--paper-header-panel-body);
       }
+      
+      @media print {
+        :host { display: block }
+        #mainContainer { display: block }
+        #mainPanel { display: block }
+      }
 
       /*
        * mode: scroll


### PR DESCRIPTION
This makes a page using `paper-header-panel` + `paper-drawer-panel` printable. Without these rules it prints only the first page.

Related: https://github.com/PolymerElements/paper-drawer-panel/pull/148
